### PR TITLE
#1 adding component info

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "easing",
+  "version": "0.5.4",
+  "description": "Generic set of easing functions with AMD support",
+  "authors": [
+    "Dan Rogers <dan@danro.net>"
+  ],
+  "license": "MIT",
+  "keywords": ["animation", "easing", "tween"],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/danro/easing-js.git"
+  },
+  "ignore": [
+    "node_modules"
+  ],
+  "dependencies": {
+  }
+}


### PR DESCRIPTION
Related to #1, this commit mirrors the component info from `package.json` so it can be added to the Bower registry. 
