### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git://github.com/danro/easing-js.git"
   },
+  "main": [
+    "./**/*"
+  ],
   "ignore": [
     "node_modules"
   ],


### PR DESCRIPTION
Update bower.json to add a "main" entry.
It suppresses the warning (below) occuring with Bower installation of easing-js.

bower easing#\*   invalid-meta easing is missing "main" entry in bower.json
